### PR TITLE
Fix README's git clone instructions (for oh-my-zsh)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Add `Plug horosgrisa/autoenv` into `.zshrc`
 
 ### Using [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh)
 
-Execute `git clone https://github.com/horosgrisa/autoenv ~/.oh-my-zsh/custom/plugins`. Add `autoenv` into plugins array in `.zshrc`
+Execute `git clone https://github.com/horosgrisa/autoenv ~/.oh-my-zsh/custom/plugins/autoenv`. Add `autoenv` into plugins array in `.zshrc`
 
 ### Using [antigen](https://github.com/zsh-users/antigen)
 


### PR DESCRIPTION
The original `git clone` instructions fails:

```
➜  ~  git clone https://github.com/horosgrisa/autoenv ~/.oh-my-zsh/custom/plugins/
fatal: destination path '/home/nagasaki45/.oh-my-zsh/custom/plugins' already exists and is not an empty directory.
```
