### PR TITLE
grep --quiet instead of redirecting stdout and stderr to /dev/null

### DIFF
--- a/autoenv.plugin.zsh
+++ b/autoenv.plugin.zsh
@@ -67,7 +67,7 @@ check_and_exec(){
     else
         hash=$(sha1sum "$1" | cut -d' ' -f 1)
     fi
-    if grep "$1:$hash" "$AUTOENV_AUTH_FILE" >/dev/null 2>/dev/null
+    if grep --quiet "$1:$hash" "$AUTOENV_AUTH_FILE"
     then
         envfile=$1
         shift


### PR DESCRIPTION
No change in behavior, only refactoring, which result in a nicer code, IMHO.
