### PR TITLE
Allow user to change default settings filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,12 @@ Autoenv
 
 This plugin support for enter and leave events. By default `.env` is used for entering, and `.out` for leaving. And you can set variable `COLORS=true` for enabling colored output.
 
+The environment variables `$AUTOENV_IN_FILE` & `$AUTOENV_OUT_FILE` can be used
+to override the default values for the names of `.env` & `.out` respectively.
+
 ## Example of use
 
-- If you are in the directory `/home/user/dir1` and execute `cd /var/www/myproject` this plugin will source following files if they exist 
+- If you are in the directory `/home/user/dir1` and execute `cd /var/www/myproject` this plugin will source following files if they exist
 ```
 /home/user/dir1/.out
 /home/user/.out
@@ -17,14 +20,14 @@ This plugin support for enter and leave events. By default `.env` is used for en
 /var/www/myproject/.env
 ```
 
-- If you are in the directory `/` and execute `cd /home/user/dir1` this plugin will source following files if they exist 
+- If you are in the directory `/` and execute `cd /home/user/dir1` this plugin will source following files if they exist
 ```
 /home/.env
 /home/user/.env
 /home/user/dir1/.env
 ```
 
-- If you are in the directory `/home/user/dir1` and execute `cd /` this plugin will source following files if they exist 
+- If you are in the directory `/home/user/dir1` and execute `cd /` this plugin will source following files if they exist
 ```
 /home/user/dir1/.out
 /home/user/.out

--- a/autoenv.plugin.zsh
+++ b/autoenv.plugin.zsh
@@ -9,6 +9,14 @@ if [[ -z $COLORS ]]; then
     COLORS=true
 fi
 
+if [[ -z $AUTOENV_IN_FILE ]]; then
+  AUTOENV_IN_FILE=".env"
+fi
+
+if [[ -z $AUTOENV_OUT_FILE ]]; then
+  AUTOENV_OUT_FILE=".out"
+fi
+
 check_and_run(){
     if [[ $COLORS == true ]]
     then
@@ -73,9 +81,9 @@ autoenv_init(){
 
     while [[ ! "$_AUTOENV_NEWPATH" == "$_AUTOENV_OLDPATH"* ]]
     do
-        if [[ -f "$_AUTOENV_OLDPATH/.out" ]]
+        if [[ -f "$_AUTOENV_OLDPATH/$AUTOENV_OUT_FILE" ]]
         then
-            check_and_exec "$_AUTOENV_OLDPATH/.out"
+            check_and_exec "$_AUTOENV_OLDPATH/$AUTOENV_OUT_FILE"
         fi
         _AUTOENV_OLDPATH="$(dirname $_AUTOENV_OLDPATH)"
     done
@@ -87,17 +95,17 @@ autoenv_init(){
     while [[ ! "$_AUTOENV_OLDPATH" == "$_AUTOENV_NEWPATH"  ]]
     do
         _AUTOENV_OLDPATH="$_AUTOENV_OLDPATH$(echo -n '/'; echo ${_AUTOENV_NEWPATH#${_AUTOENV_OLDPATH}} | tr \/ "\n" | sed -n '2p' )"
-        if [[ -f "$_AUTOENV_OLDPATH/.env" ]]
+        if [[ -f "$_AUTOENV_OLDPATH/$AUTOENV_IN_FILE" ]]
         then
-            check_and_exec "$_AUTOENV_OLDPATH/.env"
+            check_and_exec "$_AUTOENV_OLDPATH/$AUTOENV_IN_FILE"
         fi
     done
-        
+
 }
 
-if [[ -f "./.env" ]]
+if [[ -f "./$AUTOENV_IN_FILE" ]]
 then
-    check_and_exec "./.env"
+    check_and_exec "./$AUTOENV_IN_FILE"
 fi
 
 chpwd_functions+=( autoenv_init )


### PR DESCRIPTION
After working with some Laravel projects and this module loaded, I've had to deal with name collisions. Laravel uses a `.env` file for its environment settings, which does not play nicely with the zsh script I write. 

I allow the user to set environment variables `$AUTOENV_IN_FILE` & `$AUTOENV_OUT_FILE` to override `.env` and `.out` respectively. 
