### PR TITLE
Ensure that the initial directory has the autoenv scripts called

### DIFF
--- a/autoenv.plugin.zsh
+++ b/autoenv.plugin.zsh
@@ -108,4 +108,8 @@ then
     check_and_exec "./$AUTOENV_IN_FILE"
 fi
 
+() {
+    local OLDPWD='/'
+    autoenv_init
+}
 chpwd_functions+=( autoenv_init )


### PR DESCRIPTION
This removes the need to cd for effect when starting a new terminal.
