### PR TITLE
Fix 'command not found: add-zsh-hook'

### DIFF
--- a/autoenv.plugin.zsh
+++ b/autoenv.plugin.zsh
@@ -73,7 +73,7 @@ check_and_exec(){
     shift
     PWD="$(dirname $envfile)" source "$envfile"
   else
-  echo 
+  echo
     check_and_run "$1" "$hash"
   fi
 }
@@ -111,5 +111,6 @@ _autoenv_first_run(){
   add-zsh-hook -d precmd _autoenv_first_run
 }
 
+autoload -Uz add-zsh-hook
 add-zsh-hook precmd _autoenv_first_run
 add-zsh-hook chpwd autoenv_chdir


### PR DESCRIPTION
Looks like this was introduced in e92e1400c6664eb2b2ee1b3ee0e36f65ccee20b4.