### PR TITLE
Fix: get stuck when shwordsplit is set

### DIFF
--- a/functions/autoenv_chdir
+++ b/functions/autoenv_chdir
@@ -3,8 +3,8 @@
 local IFS=/
 local old=( $(echo "$OLDPWD") )
 local new=( $(echo "$PWD") )
-old=( ${old[@]} ) # drop empty elements
-new=( ${new[@]} )
+old=( ${old:#} ) # drop empty elements
+new=( ${new:#} )
 
 local concat=( $old $(echo "${new#$old}") ) # this may introduce empty elements
 concat=( ${concat[@]} ) # so we remove them


### PR DESCRIPTION
When `shwordsplit` is set by

```
setopt shwordsplit
```

autoenv just get stuck sometimes. That's because that the following line doesn't drop empty elements successfully when `shwordsplit` is set:

```
old=( ${old[@]} ) # drop empty elements
```

So I change it to a zsh-style method as suggested [here](https://unix.stackexchange.com/questions/590029/remove-all-empty-strings-from-an-array-in-zsh).