### PR TITLE
Pass the directory being entered/exited as an argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ to override the default values for the file names of `.in` & `.out` respectively
 
 ## Examples of `.in` and `.out` files
 
-Please, don't use `pwd` or `$PWD`, instead of this use `$(dirname $0)`
+Please, don't use `pwd` or `$PWD`, instead of this use `$(dirname $0)`. Additionally, the path of the directory being entered or exited is passed as the first argument to both `.in` and `.out` scripts, should using a symlink be preferred.
 
 ### For node.js developing:
 

--- a/functions/autoenv_chdir
+++ b/functions/autoenv_chdir
@@ -21,6 +21,6 @@ done
 while [[ ! "$old" == "$new" ]]; do
   old+=(${new[((1 + $#old))]}) # append next element
   if [[ -f "/$old/$AUTOENV_IN_FILE" ]]; then
-    autoenv_check_and_exec "/$old/$AUTOENV_IN_FILE"
+    autoenv_check_and_exec "/$old/$AUTOENV_IN_FILE" "/$old"
   fi
 done

--- a/functions/autoenv_check_and_exec
+++ b/functions/autoenv_check_and_exec
@@ -8,11 +8,11 @@ else
   hash=$(sha1sum "$1" | cut -d' ' -f 1)
 fi
 
-if grep -q "$1:$hash" "$AUTOENV_AUTH_FILE"; then
-  envfile="$1"
-  shift
-  source "$envfile"
+local envfile="$1"
+shift
+if grep -q "$envfile:$hash" "$AUTOENV_AUTH_FILE"; then
+  source "$envfile" "$@"
 else
   echo
-  autoenv_check_and_run "$1" "$hash"
+  autoenv_check_and_run "$envfile" "$hash" "$@"
 fi

--- a/functions/autoenv_check_and_run
+++ b/functions/autoenv_check_and_run
@@ -24,5 +24,6 @@ if [[ "$answer" == "y" || "$answer" == "Y" || "$answer" == "yes" ]]; then
   echo "$1:$2" >> "$AUTOENV_AUTH_FILE"
   envfile=$1
   shift
-  source "$envfile"
+  shift
+  source "$envfile" "$@"
 fi


### PR DESCRIPTION
Not sure if this is desirable - but I have several .in and .out scripts that are shared and I'd like to symlink them. This also helps with backing up the .in and .out files (e.g. in a Git repository.)

Because symlinks are resolved to the target before execution, $0 points to the target of the symlink. I saw some code which tries to give the directory being exited/entered ($old) but was not properly propagated - I just passed it downward.