### PR TITLE
Add Fig as an installation method to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ Add `zpm load zpm-zsh/autoenv` into `.zshrc`
 
 Execute `git clone https://github.com/zpm-zsh/autoenv ~/.oh-my-zsh/custom/plugins/autoenv`. Add `autoenv` into plugins array in `.zshrc`
 
+### Using [Fig](https://fig.io)
+
+Fig adds apps, shortcuts, and autocomplete to your existing terminal.
+
+Install `autoenv` in just one click.
+
+<a href="https://fig.io/plugins/other/autoenv_zpm-zsh" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
+
 ### Using [antigen](https://github.com/zsh-users/antigen)
 
 Add `antigen bundle zpm-zsh/autoenv` into `.zshrc`


### PR DESCRIPTION
The [Fig Plugin Store](https://fig.io/plugins) supports 1-click install for 400+ shell plugins. We have over 100k users, thousands of whom manage their shell configuration with Fig.

Autoenv is already listed in the store so we'd love to have it listed as a download method on your readme.

Thanks so much and please let me know if you have any questions!

